### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -1,3 +1,4 @@
+
 name: "grafana-dashboards"
 # Canonical GitHub repo
 github_repo: "cloudposse/grafana-dashboards"


### PR DESCRIPTION
Change all references to  , since  redirects will stop working on April 29th, 2022. See here for more information: DEV-143